### PR TITLE
Fix 500 server error

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -6,7 +6,7 @@ function patchGQLQuery(obj)
         report_clause = {};
     }
     report_clause["team"] = team_condition;
-    obj["variables"]["report"] = report_clause;
+    obj["variables"]["where"]["report"] = report_clause;
     console.log(obj);
     return obj;
 }

--- a/cs.js
+++ b/cs.js
@@ -1,12 +1,12 @@
 function patchGQLQuery(obj)
 {
     team_condition = {"state":{"_eq":"soft_launched"}};
-    where_clause = obj["variables"]["where"];
-    if(where_clause === null || where_clause === undefined){
-        where_clause = {};
+    report_clause = obj["variables"]["where"]["report"];
+    if(report_clause === null || report_clause === undefined){
+        report_clause = {};
     }
-    where_clause["team"] = team_condition;
-    obj["variables"]["where"] = where_clause;
+    report_clause["team"] = team_condition;
+    obj["variables"]["report"] = report_clause;
     console.log(obj);
     return obj;
 }


### PR DESCRIPTION
Hi Yashrs,

I applied a fix for 500 server error by moving the `team` condition inside the `report` object. Now user can view there private program disclosed reports by going to https://hackerone.com/hacktivity

**Before**
```
where: { report: [Object], team: [Object] }
```

**Now**
```
where: { report: [Object] }
```

